### PR TITLE
Alpine 3.8, file, ctop, libc-compat (required for ctop), Readme & Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN set -ex \
     dhcping \
     drill \
     ethtool \
+    file\
     fping \
     iftop \
     iperf \
@@ -24,6 +25,7 @@ RUN set -ex \
     iptraf-ng \
     iputils \
     ipvsadm \
+    libc6-compat \
     liboping \
     mtr \
     net-snmp-tools \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:3.8
 
 RUN set -ex \
     && echo "http://nl.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories \
@@ -46,8 +46,11 @@ RUN set -ex \
 # apparmor issue #14140
 RUN mv /usr/sbin/tcpdump /usr/bin/tcpdump
 
+# Installing ctop - top-like container monitor
+RUN wget https://github.com/bcicen/ctop/releases/download/v0.7.1/ctop-0.7.1-linux-amd64 -O /usr/local/bin/ctop && chmod +x /usr/local/bin/ctop
+
 # Installing calicoctl
-RUN wget https://github.com/projectcalico/calicoctl/releases/download/v3.1.1/calicoctl && chmod +x calicoctl && mv calicoctl /usr/local/bin
+RUN wget https://github.com/projectcalico/calicoctl/releases/download/v3.1.1/calicoctl -O /usr/local/bin/calicoctl && chmod +x /usr/local/bin/calicoctl 
 
 # Netgen
 ADD netgen.sh /usr/local/bin/netgen

--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ To troubleshoot these issues, `netshoot` includes a set of powerful tools as rec
     curl 
     dhcping 
     drill 
-    ethtool 
+    ethtool
+    file 
     fping 
     iftop 
     iperf 
@@ -60,7 +61,8 @@ To troubleshoot these issues, `netshoot` includes a set of powerful tools as rec
     iptables 
     iptraf-ng 
     iputils 
-    ipvsadm 
+    ipvsadm
+    libc6-compat 
     liboping 
     mtr 
     net-snmp-tools 
@@ -429,7 +431,7 @@ More info on `iproute2` [here](http://lartc.org/howto/lartc.iproute2.tour.html)
 
 ## nsenter
 
-Prupose: `nsenter` is a powerful tool allowing you to enter into any namespaces. `nsenter` is available inside `netshoot` but requires `netshoot` to be run as a privileged container. Additionally, you may want to mount the `/var/run/docker/netns` directory to be able to enter any network namespace including bridge and overlay networks. 
+Purpose: `nsenter` is a powerful tool allowing you to enter into any namespaces. `nsenter` is available inside `netshoot` but requires `netshoot` to be run as a privileged container. Additionally, you may want to mount the `/var/run/docker/netns` directory to be able to enter any network namespace including bridge and overlay networks. 
 
 
 With `docker run --name container-B --net container:container-A `, docker uses `container-A`'s network namespace ( including interfaces and routes) when creating `container-B`. This approach is helpful for troubleshooting network issues at the container level. To troubleshoot network issues at the bridge or overlay network level, you need to enter the `namespace` of the network _itself_. `nsenter` allows you to do that. 
@@ -614,6 +616,23 @@ br0		8000.0215b8e7deb3	no		vxlan1
 							veth4
 							
 ```
+
+## CTOP
+ ctop is a free open source, simple and cross-platform top-like command-line tool for monitoring container metrics in real-time. It allows you to get an overview of metrics concerning CPU, memory, network, I/O for multiple containers and also supports inspection of a specific container.
+
+ # To get data into ctop, you'll need to bind docker.sock into the netshoot container.
+/ # docker run -it --rm -v /var/run/docker.sock:/var/run/docker.sock netshoot
+
+```
+ ctop - 15:10:23 UTC   2 containers
+
+   NAME                                   CID                                    CPU                                    MEM                                    NET RX/TX                              IO R/W                                 PIDS
+
+ ◉  quirky_lichterman                      3b4fdde356fa                                              1%                                 5M / 1.95G              828B / 0B                              0B / 0B                                13
+ ◉  condescending_blackwell                f00dcc0e50dd                                              -                                      -                   -                                      -                                      -
+```
+It will display running and existed containers with useful metrics to help troubleshoot resource issues; hit "q" to exit.
+
 
 
 ## Feedback + Contribution


### PR DESCRIPTION
1. Updated Alpine to version 3.8
2. Added file, to query file-types
3. Added libc-compat as a dependency for ctop
4. Added ctop, a slick top-like container resource monitor showing cpu, memory, network, etc real-time metrics
5. Updated the README.md with instructions that bind mount docker.sock for ctop and a spelling correction.
6. Updated the Dockerfile 
7. Simpified up the calicoctl wget string