### PR TITLE
Spin up a throw away container without deprecation warning.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Cool thing about namespaces is that you can switch between them. You can enter a
 
 **Kubernetes:** If you want to spin up a throw away container for debugging.
 
-`$ kubectl run tmp-shell --rm -i --tty --image nicolaka/netshoot -- /bin/bash`
+`$ kubectl run --generator=run-pod/v1 tmp-shell --rm -i --tty --image nicolaka/netshoot -- /bin/bash`
 
 And if you want to spin up a container on the host's network namespace.
 


### PR DESCRIPTION
"kubectl run tmp-shell --generator=run-pod/v1" also generates a pod not a deployment making it easier to handle.
Deprecation warning in kubectl 1.15 was:
"kubectl run --generator=deployment/apps.v1 is DEPRECATED and will be removed in a future version. Use kubectl run --generator=run-pod/v1 or kubectl create instead."