### PR TITLE
Add gRPC tools grpcurl and ghz

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,6 +70,22 @@ RUN wget https://github.com/gcla/termshark/releases/download/v${TERMSHARK_VERSIO
     mv termshark_${TERMSHARK_VERSION}_linux_x64/termshark /usr/local/bin/termshark && \
     chmod +x /usr/local/bin/termshark
 
+# Installing gRPCurl
+ENV GRPCURL_VERSION 1.6.0
+RUN wget https://github.com/fullstorydev/grpcurl/releases/download/v${GRPCURL_VERSION}/grpcurl_${GRPCURL_VERSION}_linux_x86_64.tar.gz -O /tmp/grpcurl_${GRPCURL_VERSION}_linux_x86_64.tar.gz && \
+    mkdir ./grpcurl_${GRPCURL_VERSION}_linux_x86_64 && \
+    tar -zxvf /tmp/grpcurl_${GRPCURL_VERSION}_linux_x86_64.tar.gz -C grpcurl_${GRPCURL_VERSION}_linux_x86_64/ && \
+    mv grpcurl_${GRPCURL_VERSION}_linux_x86_64/grpcurl /usr/local/bin/grpcurl && \
+    chmod +x /usr/local/bin/grpcurl
+
+# Installing ghz
+ENV GHZ_VERSION 0.55.0
+RUN wget https://github.com/bojand/ghz/releases/download/v${GHZ_VERSION}/ghz-linux-x86_64.tar.gz -O /tmp/ghz-linux-x86_64.tar.gz && \
+    mkdir ./ghz_${GHZ_VERSION} && \
+    tar -zxvf /tmp/ghz-linux-x86_64.tar.gz -C ghz_${GHZ_VERSION}/ && \
+    mv ghz_${GHZ_VERSION}/ghz /usr/local/bin/ghz && \
+    rm ghz_${GHZ_VERSION}/ghz-web && \
+    chmod +x /usr/local/bin/ghz
 
 # Settings
 ADD motd /etc/motd


### PR DESCRIPTION
Add the grpcurl and ghz packages to netshoot.
- https://github.com/fullstorydev/grpcurl
- https://github.com/bojand/ghz/

Ghz package contains both `ghz` and `ghz-web` but when I tried to run `ghz-web` I got the following error:

```
bash-5.0# ./ghz-web
Error relocating ./ghz-web: __memcpy_chk: symbol not found
Error relocating ./ghz-web: __memset_chk: symbol not found
```

Seems like an issue with Alpine and glibc? I personally only cared about `ghz` so I removed `ghz-web` to not make the container bigger unnecessarily.