### PR TITLE
Add a multi-arch build so that this can be used from RPi based kubernetes

### DIFF
--- a/.github/workflows/docker-buildx.yml
+++ b/.github/workflows/docker-buildx.yml
@@ -1,0 +1,33 @@
+name: buildx
+
+on:
+  pull_request:
+    branches: master
+  push:
+    branches: master
+    tags:
+
+jobs:
+  buildx:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Set up Docker Buildx
+        id: buildx
+        uses: crazy-max/ghaction-docker-buildx@v3
+        with:
+          buildx-version: latest
+          qemu-version: latest
+      -
+        name: Available platforms
+        run: echo ${{ steps.buildx.outputs.platforms }}
+      -
+        name: Run Buildx
+        run: |
+          docker buildx build \
+            --platform linux/amd64,linux/arm64 \
+            --output "type=image,push=false" \
+            --file ./Dockerfile .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,12 @@
+FROM debian:stable-slim as fetcher
+COPY build/fetch_binaries.sh /tmp/fetch_binaries.sh
+
+RUN apt-get update && apt-get install -y \
+  curl \
+  wget
+
+RUN /tmp/fetch_binaries.sh
+
 FROM alpine:3.9
 
 RUN set -ex \
@@ -57,19 +66,13 @@ RUN set -ex \
 RUN mv /usr/sbin/tcpdump /usr/bin/tcpdump
 
 # Installing ctop - top-like container monitor
-RUN wget https://github.com/bcicen/ctop/releases/download/v0.7.1/ctop-0.7.1-linux-amd64 -O /usr/local/bin/ctop && chmod +x /usr/local/bin/ctop
+COPY --from=fetcher /tmp/ctop /usr/local/bin/ctop
 
 # Installing calicoctl
-ARG CALICOCTL_VERSION=v3.13.3
-RUN wget https://github.com/projectcalico/calicoctl/releases/download/${CALICOCTL_VERSION}/calicoctl && chmod +x calicoctl && mv calicoctl /usr/local/bin
+COPY --from=fetcher /tmp/calicoctl /usr/local/bin/calicoctl
 
 # Installing termshark
-ENV TERMSHARK_VERSION 2.1.1
-RUN wget https://github.com/gcla/termshark/releases/download/v${TERMSHARK_VERSION}/termshark_${TERMSHARK_VERSION}_linux_x64.tar.gz -O /tmp/termshark_${TERMSHARK_VERSION}_linux_x64.tar.gz && \
-    tar -zxvf /tmp/termshark_${TERMSHARK_VERSION}_linux_x64.tar.gz && \
-    mv termshark_${TERMSHARK_VERSION}_linux_x64/termshark /usr/local/bin/termshark && \
-    chmod +x /usr/local/bin/termshark
-
+COPY --from=fetcher /tmp/termshark /usr/local/bin/termshark
 
 # Settings
 ADD motd /etc/motd

--- a/build/fetch_binaries.sh
+++ b/build/fetch_binaries.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+get_latest_release() {
+  curl --silent "https://api.github.com/repos/$1/releases/latest" | # Get latest release from GitHub api
+    grep '"tag_name":' |                                            # Get tag line
+    sed -E 's/.*"([^"]+)".*/\1/'                                    # Pluck JSON value
+}
+
+
+ARCH=$(uname -m)
+case $ARCH in
+    x86_64)
+        ARCH=amd64
+        ;;
+    aarch64)
+        ARCH=arm64
+        ;;
+esac
+
+get_ctop() {
+  VERSION=$(get_latest_release bcicen/ctop | sed -e 's/^v//')
+  LINK="https://github.com/bcicen/ctop/releases/download/v${VERSION}/ctop-${VERSION}-linux-${ARCH}"
+  wget "$LINK" -O /tmp/ctop && chmod +x /tmp/ctop
+}
+
+get_calicoctl() {
+  VERSION=$(get_latest_release projectcalico/calicoctl)
+  LINK="https://github.com/projectcalico/calicoctl/releases/download/${VERSION}/calicoctl-linux-${ARCH}"
+  wget "$LINK" -O /tmp/calicoctl && chmod +x /tmp/calicoctl
+}
+
+get_termshark() {
+  case "$ARCH" in
+    "arm"*)
+      echo "echo termshark does not yet support arm" > /tmp/termshark && chmod +x /tmp/termshark
+      ;;
+    *)
+      VERSION=$(get_latest_release gcla/termshark | sed -e 's/^v//')
+      if [ "$ARCH" == "amd64" ]; then
+        TERM_ARCH=x64
+      else
+        TERM_ARCH="$ARCH"
+      fi
+      LINK="https://github.com/gcla/termshark/releases/download/v${VERSION}/termshark_${VERSION}_linux_${TERM_ARCH}.tar.gz"
+      wget "$LINK" -O /tmp/termshark.tar.gz && \
+      tar -zxvf /tmp/termshark.tar.gz && \
+      mv "termshark_${VERSION}_linux_${TERM_ARCH}/termshark" /tmp/termshark && \
+      chmod +x /tmp/termshark
+      ;;
+  esac
+}
+
+get_ctop
+get_calicoctl
+get_termshark


### PR DESCRIPTION
I'm hoping to be able to use netshoot via dockerhub on my RPi based kubernetes cluster. I've done most of the work to get it working on ARM64, the last piece would be to set up the multiarch push. I just used this github action avaiable from the marketplace, and they have an example of setting up the docker hub push:

https://github.com/marketplace/actions/docker-buildx

I'm hoping I can avoid setting up my own dockerhub account, so I hope you see this and approve. 

Thanks for such a great tool!  