### PR TITLE
fix #56

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && apt-get install -y \
 
 RUN /tmp/fetch_binaries.sh
 
-FROM alpine:3.11
+FROM alpine:3.13
 
 RUN set -ex \
     && echo "http://nl.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories \
@@ -49,7 +49,6 @@ RUN set -ex \
     nmap \
     nmap-nping \
     openssl \
-    py-crypto \
     scapy \
     socat \
     strace \
@@ -59,10 +58,6 @@ RUN set -ex \
     util-linux \
     vim \
     websocat
-
-
-# apparmor issue #14140
-RUN mv /usr/sbin/tcpdump /usr/bin/tcpdump
 
 # Installing ctop - top-like container monitor
 COPY --from=fetcher /tmp/ctop /usr/local/bin/ctop


### PR DESCRIPTION
I upgraded netshoot to alpine 3.13 and confirmed that gnutls and opensll have newer versions. jq's latest official release is still 1.6-r1.

```
  → apk info gnutls openssl jq
gnutls-3.7.0-r0 description:
TLS protocol implementation

gnutls-3.7.0-r0 webpage:
https://www.gnutls.org/

gnutls-3.7.0-r0 installed size:
1868 KiB

gnutls-3.7.0-r0 description:
TLS protocol implementation

gnutls-3.7.0-r0 webpage:
https://www.gnutls.org/

gnutls-3.7.0-r0 installed size:
1868 KiB

openssl-1.1.1i-r0 description:
Toolkit for Transport Layer Security (TLS)

openssl-1.1.1i-r0 webpage:
https://www.openssl.org/

openssl-1.1.1i-r0 installed size:
664 KiB

jq-1.6-r1 description:
A lightweight and flexible command-line JSON processor

jq-1.6-r1 webpage:
https://stedolan.github.io/jq/

jq-1.6-r1 installed size:
564 KiB

jq-1.6-r1 description:
A lightweight and flexible command-line JSON processor

jq-1.6-r1 webpage:
https://stedolan.github.io/jq/

jq-1.6-r1 installed size:
560 KiB
```