### PR TITLE
Add DNS-over-TLS and DNS-over-HTTPS query capability via kdigs 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN set -ex \
     iputils \
     ipvsadm \
     jq \
-    knot-dnsutils \
+    knot-utils \
     libc6-compat \
     liboping \
     mtr \

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,7 @@ RUN set -ex \
     iputils \
     ipvsadm \
     jq \
+    knot-dnsutils \
     libc6-compat \
     liboping \
     mtr \


### PR DESCRIPTION
add DNS-over-TLS and DNS-over-HTTPS query capability by adding kdig from KNOT DNS project in its Alpine Linux package flavor. 