### PR TITLE
Adding iperf3 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,9 +31,10 @@ RUN set -ex \
     fping \
     iftop \
     iperf \
+    iperf3 \
     iproute2 \
     ipset \
-    iptables \ 
+    iptables \
     iptraf-ng \
     iputils \
     ipvsadm \
@@ -58,7 +59,7 @@ RUN set -ex \
     tcptraceroute \
     tshark \
     util-linux \
-    vim \ 
+    vim \
     git \
     zsh \
     websocat


### PR DESCRIPTION
iperf3 is recommended vs iperf (v2) for most use cases. Still leaving iperf for some particular cases like multicast testing.