### PR TITLE
Upgrade alpine 3.13 to 3.14 to fix vulnerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && apt-get install -y \
 
 RUN /tmp/fetch_binaries.sh
 
-FROM alpine:3.13
+FROM alpine:3.14
 
 RUN set -ex \
     && echo "http://nl.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories \


### PR DESCRIPTION
Fix vulnerabilities 

```sh
CVE-2021-25218  Finding High bind-libs  9.16.19-r0  9.16.20-r0  Package
CVE-2021-25218  Finding High bind-tools 9.16.19-r0  9.16.20-r0  Package
CVE-2021-3712 Finding High openssl  1.1.1k-r1 1.1.1l-r0 Package
CVE-2021-3711 Finding Cri ical libcrypto1.1 1.1.1k-r1 1.1.1l-r0 Package
CVE-2021-3711 Finding Cri ical libssl1.1  1.1.1k-r1 1.1.1l-r0 Package
CVE-2021-3712 Finding High libcrypto1.1 1.1.1k-r1 1.1.1l-r0 Package
CVE-2021-3711 Finding Cri ical openssl  1.1.1k-r1 1.1.1l-r0 Package
CVE-2021-3712 Finding High libssl1.1  1.1.1k-r1 1.1.1l-r0 Package
CVE-2021-3770 Finding High xxd  8.2.3156-r0 8.2.3437-r0 Package
CVE-2021-3770 Finding High vim  8.2.3156-r0 8.2.3437-r0 Package
CVE-2021-22946  Finding High curl 7.78.0-r0 7.79.0-r0 Package
CVE-2021-22945  Finding Cri ical curl 7.78.0-r0 7.79.0-r0 Package
CVE-2021-22946  Finding High libcurl  7.78.0-r0 7.79.0-r0 Package
CVE-2021-22945  Finding Cri ical libcurl  7.78.0-r0 7.79.0-r0 Package
CVE-2021-33193  Finding High apache2-utils  2.4.48-r0 2.4.49-r0 Package
CVE-2021-34798  Finding High apache2-utils  2.4.48-r0 2.4.49-r0 Package
CVE-2021-39275  Finding Cri ical apache2-utils  2.4.48-r0 2.4.49-r0 Package
CVE-2021-40438  Finding Cri ical apache2-utils  2.4.48-r0 2.4.49-r0 Package
CVE-2021-36160  Finding High apache2-utils  2.4.48-r0 2.4.49-r0 Package
CVE-2021-3796 Finding High vim  8.2.3156-r0 8.2.3437-r0 Package
CVE-2021-3778 Finding High xxd  8.2.3156-r0 8.2.3437-r0 Package
CVE-2021-3778 Finding High vim  8.2.3156-r0 8.2.3437-r0 Package
CVE-2021-3796 Finding High xxd  8.2.3156-r0 8.2.3437-r0 Package
CVE-2021-41524  Finding High apache2-utils  2.4.48-r0 2.4.50-r0 Package
```