### PR TITLE
Install nmap scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,7 @@ RUN set -ex \
     ngrep \
     nmap \
     nmap-nping \
+    nmap-scripts \
     openssl \
     py3-pip \
     py3-setuptools \


### PR DESCRIPTION
Needed to scan TLS ciphersuites on a remote server, i.e.
```bash
bash-5.1# nmap --script ssl-enum-ciphers -p 443 google.com
Starting Nmap 7.92 ( https://nmap.org ) at 2022-01-15 13:05 UTC
Nmap scan report for google.com (142.250.69.206)
Host is up (0.015s latency).
Other addresses for google.com (not scanned): 2607:f8b0:400a:806::200e
rDNS record for 142.250.69.206: sea30s08-in-f14.1e100.net

PORT    STATE SERVICE
443/tcp open  https
| ssl-enum-ciphers: 
|   TLSv1.0: 
|     ciphers: 
|       TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA (ecdh_x25519) - A
|       TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA (ecdh_x25519) - A
|       TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA (ecdh_x25519) - A
|       TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA (ecdh_x25519) - A
|       TLS_RSA_WITH_AES_128_CBC_SHA (rsa 2048) - A
|       TLS_RSA_WITH_AES_256_CBC_SHA (rsa 2048) - A
|       TLS_RSA_WITH_3DES_EDE_CBC_SHA (rsa 2048) - C
|     compressors: 
|       NULL
....
```
So install teh nmap scripts package