### PR TITLE
Add ltrace

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,7 @@ RUN set -ex \
     jq \
     libc6-compat \
     liboping \
+    ltrace \
     mtr \
     net-snmp-tools \
     netcat-openbsd \

--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ To troubleshoot these issues, `netshoot` includes a set of powerful tools as rec
     jq
     libc6-compat
     liboping
+    ltrace
     mtr
     net-snmp-tools
     netcat-openbsd


### PR DESCRIPTION
Tool [strace](https://man7.org/linux/man-pages/man1/strace.1.html) is included in the image, let's add [ltrace](https://man7.org/linux/man-pages/man1/ltrace.1.html). Sometimes is valuable and convenient to see just calls to libraries.