### PR TITLE
Introduce Dependabot for Docker and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: daily
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily


### PR DESCRIPTION
As mentioned in https://github.com/nicolaka/netshoot/issues/111#issuecomment-1212307608 introduce automated updates for base images in `Dockerfile` and GitHub Actions used in CI. It will check for updates every day and create PRs automatically for us - keeping them up to date should allow avoiding most security vulnerabilities