### PR TITLE
arm64 is now supported in termshark

### DIFF
--- a/build/fetch_binaries.sh
+++ b/build/fetch_binaries.sh
@@ -32,9 +32,6 @@ get_calicoctl() {
 
 get_termshark() {
   case "$ARCH" in
-    "arm"*)
-      echo "echo termshark does not yet support arm" > /tmp/termshark && chmod +x /tmp/termshark
-      ;;
     *)
       VERSION=$(get_latest_release gcla/termshark | sed -e 's/^v//')
       if [ "$ARCH" == "amd64" ]; then


### PR DESCRIPTION
Arm is supported for `termshark` since https://github.com/gcla/termshark/commit/674620e1e5447cb4ddfb884048b63f217a8b4662

This suppresses #94 as everything else proposed there is already implemented.

Signed-off-by: Nikolay Nikolaev <nicknickolaev@gmail.com>