### PR TITLE
Include bpftool in base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN set -ex \
     bash \
     bind-tools \
     bird \
+    bpftool \
     bridge-utils \
     busybox-extras \
     conntrack-tools \


### PR DESCRIPTION
It would be convenient to pre-install `bpftool` inside this image. While not a common networking tool, bpftool can be leveraged to inspect eBPF maps and programs that are created and manage networking traffic on a host. For example, Cilium creates a multitude of maps and programs, having bpftool pre-installed allows folks to use it to investigate any issues with those. 