### PR TITLE
bump some dependencies versions to remove all current critical CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && apt-get install -y \
 
 RUN /tmp/fetch_binaries.sh
 
-FROM alpine:3.18.0
+FROM alpine:3.18.4
 
 RUN set -ex \
     && echo "http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories \

--- a/build/fetch_binaries.sh
+++ b/build/fetch_binaries.sh
@@ -25,8 +25,8 @@ get_ctop() {
 }
 
 get_calicoctl() {
-  VERSION=$(get_latest_release projectcalico/calicoctl)
-  LINK="https://github.com/projectcalico/calicoctl/releases/download/${VERSION}/calicoctl-linux-${ARCH}"
+  VERSION=$(get_latest_release projectcalico/calico)
+  LINK="https://github.com/projectcalico/calico/releases/download/${VERSION}/calicoctl-linux-${ARCH}"
   wget "$LINK" -O /tmp/calicoctl && chmod +x /tmp/calicoctl
 }
 


### PR DESCRIPTION
from alpine base version:
    CVE-2022-48174
    CVE-2023-37920
from calicoctl:
    CVE-2021-3538
    CVE-2019-20933
    CVE-2022-1996