### PR TITLE
Update Alpine image to fix security vulnerability and minor indentation fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && apt-get install -y \
 
 RUN /tmp/fetch_binaries.sh
 
-FROM alpine:3.18.0
+FROM alpine:3.18.5
 
 RUN set -ex \
     && echo "http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories \

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,9 @@ RUN /tmp/fetch_binaries.sh
 FROM alpine:3.18.5
 
 RUN set -ex \
-    && echo "http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories \
-    && echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories \
-    && echo "http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories \
+    && echo "https://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories \
+    && echo "https://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories \
+    && echo "https://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories \
     && apk update \
     && apk upgrade \
     && apk add --no-cache \

--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,5 @@ build-arm64:
 build-all:
 		@docker buildx build --platform linux/amd64,linux/arm64 --output "type=image,push=false" --file ./Dockerfile .
 push:
-	 	@docker push ${IMAGENAME}:${VERSION} 
+	 	@docker push ${IMAGENAME}:${VERSION}
 all: build-all push
-
-
-		

--- a/build/fetch_binaries.sh
+++ b/build/fetch_binaries.sh
@@ -25,8 +25,8 @@ get_ctop() {
 }
 
 get_calicoctl() {
-  VERSION=$(get_latest_release projectcalico/calicoctl)
-  LINK="https://github.com/projectcalico/calicoctl/releases/download/${VERSION}/calicoctl-linux-${ARCH}"
+  VERSION=$(get_latest_release projectcalico/calico)
+  LINK="https://github.com/projectcalico/calico/releases/download/${VERSION}/calicoctl-linux-${ARCH}"
   wget "$LINK" -O /tmp/calicoctl && chmod +x /tmp/calicoctl
 }
 

--- a/configs/netshoot-calico.yaml
+++ b/configs/netshoot-calico.yaml
@@ -24,7 +24,7 @@ spec:
       containers:
       - image: nicolaka/netshoot
         name: netshoot
-        command: ["ping","localhost"]
+        command: ["ping", "localhost"]
         volumeMounts:
         - mountPath: /calico-secrets
           name: etcd-certs
@@ -49,13 +49,12 @@ spec:
               key: etcd_cert
               name: calico-config
       volumes:
-        - name: etcd-certs
-          secret:
-           defaultMode: 420
-           secretName: calico-etcd-secrets
-        - name: bird-ctl
-          hostPath:
-            path: /var/run/calico/bird.ctl
+      - name: etcd-certs
+        secret:
+          defaultMode: 420
+          secretName: calico-etcd-secrets
+      - name: bird-ctl
+        hostPath:
+          path: /var/run/calico/bird.ctl
       nodeSelector:
         node-role.kubernetes.io/master: ""
-

--- a/configs/netshoot-sidecar.yaml
+++ b/configs/netshoot-sidecar.yaml
@@ -1,25 +1,25 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-    name: nginx-netshoot
-    labels:
-        app: nginx-netshoot
+  name: nginx-netshoot
+  labels:
+    app: nginx-netshoot
 spec:
- replicas: 1
- selector:
+  replicas: 1
+  selector:
     matchLabels:
-        app: nginx-netshoot
- template:
+      app: nginx-netshoot
+  template:
     metadata:
-     labels:
+      labels:
         app: nginx-netshoot
     spec:
-        containers:
-        - name: nginx
-          image: nginx:1.14.2
-          ports:
-            - containerPort: 80
-        - name: netshoot
-          image: nicolaka/netshoot
-          command: ["/bin/bash"]
-          args: ["-c", "while true; do ping localhost; sleep 60;done"]
+      containers:
+      - name: nginx
+        image: nginx:1.14.2
+        ports:
+        - containerPort: 80
+      - name: netshoot
+        image: nicolaka/netshoot
+        command: ["/bin/bash"]
+        args: ["-c", "while true; do ping localhost; sleep 60;done"]

--- a/motd
+++ b/motd
@@ -6,6 +6,6 @@
 dP    dP `88888P'   dP   `88888P' dP    dP `88888P' `88888P'   dP   
                                                                     
 Welcome to Netshoot! (github.com/nicolaka/netshoot)
-Version: 0.11
+Version: 0.12
 
                                          


### PR DESCRIPTION
Hi @nicolaka,

Please help review the PR:

- The current Docker image contains some CRITICAL and HIGH vulnerabilities, update the alpine image to `3.18.5`.
- `calicoctl` has been moved to new repository: https://github.com/projectcalico/calico
- Minor fixes for some indentations.

Also you might need to setup a schedule for the GitHub workflow, so it can build and patch the Docker image.

You can run this command to scan the vulnerabilities of current image:

```
docker run --platform linux/amd64 --rm -v /var/run/docker.sock:/var/run/docker.sock aquasec/trivy:latest image --format table --ignore-unfixed --no-progress --exit-code 0 --ignore-unfixed --severity CRITICAL,HIGH --offline-scan --timeout 15m nicolaka/netshoot:v0.11
```

Thanks