### PR TITLE
fix: give grpcurl sane user/group

### DIFF
--- a/build/fetch_binaries.sh
+++ b/build/fetch_binaries.sh
@@ -60,6 +60,7 @@ get_grpcurl() {
   tar -zxvf /tmp/grpcurl.tar.gz && \
   mv "grpcurl" /tmp/grpcurl && \
   chmod +x /tmp/grpcurl
+  chown root:root /tmp/grpcurl
 }
 
 get_fortio() {


### PR DESCRIPTION
## Background

`/usr/local/bin/grpcurl` is installed with UID/GID of `708061865`/`708061865`:

```bash
 80c75558f0a4  ~  stat /usr/local/bin/grpcurl 
  File: /usr/local/bin/grpcurl
  Size: 24027136  	Blocks: 46936      IO Block: 4096   regular file
Device: 6ah/106d	Inode: 33873716    Links: 1
Access: (0755/-rwxr-xr-x)  Uid: (708061865/ UNKNOWN)   Gid: (708061865/ UNKNOWN)
Access: 2023-10-24 17:14:57.000000000 +0000
Modify: 2023-10-24 17:14:57.000000000 +0000
Change: 2024-02-16 17:40:28.913486261 +0000
```

as reported in issue #157.

This appears to be the result of the [contents of the upstream tarball](https://github.com/nicolaka/netshoot/blob/2e07274d5255711334f489622108f623fc1de520/build/fetch_binaries.sh#L58-L62).

A quick look shows that every other binary in `/usr/bin`, `/usr/sbin`, and `/usr/local/bin` have a UID/GID of `0`/`0`, except for `/usr/local/bin/termshark` which is `1000`/`1000` (and `/usr/bin/wall` group of `tty`, which we can ignore). I felt reasonably confident that setting `grpcurl` to `0`/`0` would be acceptable in this scenario.

The likely preferable approach would be to get this corrected in the upstream repo: <https://github.com/fullstorydev/grpcurl>

## Fix

- use `chown` to enforce UID/GID of `root`/`root`

## Trivial smoke test

Build new image and run it, then:

```bash
 8139862a6a48  ~  ll /usr/local/bin/grpcurl
-rwxr-xr-x    1 root     root       22.9M Oct 24 17:14 /usr/local/bin/grpcurl

 8139862a6a48  ~  grpcurl -version         
grpcurl v1.8.9
```