### PR TITLE
update repository of calicoctl to remove critical CVEs

### DIFF
--- a/build/fetch_binaries.sh
+++ b/build/fetch_binaries.sh
@@ -25,8 +25,8 @@ get_ctop() {
 }
 
 get_calicoctl() {
-  VERSION=$(get_latest_release projectcalico/calicoctl)
-  LINK="https://github.com/projectcalico/calicoctl/releases/download/${VERSION}/calicoctl-linux-${ARCH}"
+  VERSION=$(get_latest_release projectcalico/calico)
+  LINK="https://github.com/projectcalico/calico/releases/download/${VERSION}/calicoctl-linux-${ARCH}"
   wget "$LINK" -O /tmp/calicoctl && chmod +x /tmp/calicoctl
 }
 


### PR DESCRIPTION
The source code for calicoctl, has been relocated to [Project Calico’s GitHub repository](https://github.com/projectcalico/calico/). The version you’re currently using, v3.20.6, has been identified to contain several critical vulnerabilities.
However, these vulnerabilities have been addressed in subsequent versions. [As of now, the latest version of calicoctl is v3.28](https://docs.tigera.io/calico/latest/reference/calicoctl/)


![image](https://github.com/user-attachments/assets/1c6033c6-cacd-40fb-bea0-e612d5f3fb39)
