### PR TITLE
Feature: install coreutils

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN set -ex \
     bridge-utils \
     busybox-extras \
     conntrack-tools \
+    coreutils \
     curl \
     dhcping \
     drill \


### PR DESCRIPTION
Hello,

First, thank you @nicolaka for creating and maintaining this repo. It's been a life safer countless times :)

Recently I noticed `coreutils` is missing, I tried to run:

```
tshark \
  -l \
  -i eth0 \
  -f "tcp port 9000 or tcp port 9443 or tcp port 9030" \
  -o tls.keylog_file:/sslkeys/client-keys.log \
  -Y "http.request or http.response" \
  -T fields \
  -e tcp.payload \
  | stdbuf -o0 xxd -r -p
```

And noticed `stdbuf` is not installed.

Since this is image is meant for debugging I think it's nice to have the full coreutils installed instead of just the very basic ones that come with Alpine.

Note this is a breaking change since it replaces some tools like `tr`. The busybox `tr` has fewer features than the `tr` from coreutils. Other tools might also behave differently which might break some scripts users are running.

See [GNU core utilities](https://wiki.alpinelinux.org/wiki/GNU_core_utilities) on Alpine wiki