### PR TITLE
add iptables-legacy package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,7 @@ RUN set -ex \
     iproute2 \
     ipset \
     iptables \
+    iptables-legacy \
     iptraf-ng \
     iputils \
     ipvsadm \


### PR DESCRIPTION
accessing legacy iptables tables is sometimes useful
I'm personally using it rn to debug the gvisor runtime