### PR TITLE
ci: add Hadolint Dockerfile linting to PR workflow

### DIFF
--- a/.github/workflows/test-pr-buildx.yml
+++ b/.github/workflows/test-pr-buildx.yml
@@ -1,35 +1,32 @@
+---
 name: test-pr-buildx
 
 on:
   pull_request:
-    branches: master
-    
+    branches: ["master"]
+
 jobs:
   buildx:
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@v6
-      -
-        name: Set up QEMU
+      - name: Lint Dockerfile
+        uses: hadolint/hadolint-action@v3.3.0
+        with:
+          dockerfile: Dockerfile
+      - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
         with:
           platforms: arm64,amd64
-      -
-        name: Set up Docker Buildx
+      - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v3
-      -
-        name: Available platforms
+      - name: Available platforms
         run: echo ${{ steps.buildx.outputs.platforms }}
-      -
-        name: Run Buildx
+      - name: Run Buildx
         run: |
           docker buildx build \
             --platform linux/amd64,linux/arm64 \
             --output "type=image,push=false" \
             --file ./Dockerfile .
-
-
-            


### PR DESCRIPTION
- Add Hadolint Dockerfile linting step before build
- Add YAML document start marker (---)
- Fix branches to use explicit array format